### PR TITLE
Fix to back button so that it only appears on login view and passcode…

### DIFF
--- a/Yona/Yona/Others/SMSValidPasscodeLogin/Login/LoginViewController.swift
+++ b/Yona/Yona/Others/SMSValidPasscodeLogin/Login/LoginViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class LoginViewController: LoginSignupValidationMasterView {
-    @IBOutlet var backButton: UIButton!
     var loginAttempts:Int = 1
     private var totalAttempts : Int = 5
     
@@ -22,8 +21,6 @@ class LoginViewController: LoginSignupValidationMasterView {
         checkUserExists()
         
         setupPincodeScreenDifferentlyWithText(NSLocalizedString("change-pin", comment: ""), headerTitleLabelText: nil, errorLabelText: NSLocalizedString("settings_current_pin_message", comment: ""), infoLabelText: NSLocalizedString("settings_current_pin", comment: ""))
-        backButton.hidden = false
-
     }
 
     override func viewWillAppear(animated: Bool) {

--- a/Yona/Yona/Others/SMSValidPasscodeLogin/LoginSignupValidationMasterView.swift
+++ b/Yona/Yona/Others/SMSValidPasscodeLogin/LoginSignupValidationMasterView.swift
@@ -32,6 +32,7 @@ class LoginSignupValidationMasterView: UIViewController {
     @IBOutlet var avtarImage: UIImageView!
     @IBOutlet var gradientContainerView: UIView!
     @IBOutlet var errorLabel: UILabel!
+    @IBOutlet var backButton: UIButton!
     var isFromSettings = false
     
     override func viewWillDisappear(animated: Bool) {
@@ -83,6 +84,7 @@ extension LoginSignupValidationMasterView {
     func setupPincodeScreenDifferentlyWithText(screenNameLabelText: String?, headerTitleLabelText: String?, errorLabelText: String?, infoLabelText: String?) {
         if isFromSettings {
             //Nav bar Back button.
+            backButton.hidden = false
             self.screenNameLabel.text = screenNameLabelText
             topView.backgroundColor = UIColor.yiMangoColor()
             self.gradientView.colors = [UIColor.yiMangoTriangleColor(), UIColor.yiMangoTriangleColor()]
@@ -104,6 +106,7 @@ extension LoginSignupValidationMasterView {
             }
         } else {
             //Nav bar Back button.
+            backButton.hidden = true
             self.navigationItem.hidesBackButton = true
             self.navigationController?.setNavigationBarHidden(true, animated: false)
             self.gradientView.colors = [UIColor.yiGrapeTwoColor(), UIColor.yiGrapeTwoColor()]

--- a/Yona/Yona/Others/SMSValidPasscodeLogin/Passcode/ConfirmPasscodeViewController.swift
+++ b/Yona/Yona/Others/SMSValidPasscodeLogin/Passcode/ConfirmPasscodeViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 final class ConfirmPasscodeViewController:  LoginSignupValidationMasterView {
 
     var passcode: String?
-    @IBOutlet var backButton: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,7 +18,6 @@ final class ConfirmPasscodeViewController:  LoginSignupValidationMasterView {
         UIApplication.sharedApplication().setStatusBarStyle(UIStatusBarStyle.LightContent, animated: false)
         
         setupPincodeScreenDifferentlyWithText(NSLocalizedString("change-pin", comment: ""), headerTitleLabelText: NSLocalizedString("settings_confirm_new_pin", comment: ""), errorLabelText: nil, infoLabelText: NSLocalizedString("settings_confirm_new_pin_message", comment: ""))
-        backButton.hidden = true
 
     }
     

--- a/Yona/Yona/Others/SMSValidPasscodeLogin/Passcode/SetPasscodeViewController.swift
+++ b/Yona/Yona/Others/SMSValidPasscodeLogin/Passcode/SetPasscodeViewController.swift
@@ -12,9 +12,7 @@ import UIKit
 class SetPasscodeViewController: LoginSignupValidationMasterView {
     
     var passcodeString: String?
-    
-    @IBOutlet var backButton: UIButton!
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -26,7 +24,6 @@ class SetPasscodeViewController: LoginSignupValidationMasterView {
         UIApplication.sharedApplication().setStatusBarStyle(UIStatusBarStyle.LightContent, animated: false)
         
         setupPincodeScreenDifferentlyWithText(NSLocalizedString("change-pin", comment: ""), headerTitleLabelText: NSLocalizedString("settings_new_pincode", comment: ""), errorLabelText: nil, infoLabelText: NSLocalizedString("settings_new_pin_message", comment: ""))
-        backButton.hidden = false
 
     }
 


### PR DESCRIPTION
… set and confirm when we open the screens from the change pin in settings...was appearing during login not needed

- The refacturing of the repeated code in the change pin methods meant some things were not working as they should so this fix was needed to make sure buttons appear or do not appear