### PR TITLE
Feature/chandan/appdev 239

### DIFF
--- a/Yona/Yona/Array.swift
+++ b/Yona/Yona/Array.swift
@@ -14,12 +14,9 @@ extension Array {
         dateFormatter.dateFormat = "HH:mm"
         var finalZoneArray = [ToFromDate]()
         for arr in self {
-            let arrT = (arr as! String).dashRemoval()
-            finalZoneArray.append(ToFromDate(fromDate: dateFormatter.dateFromString(arrT[0]), toDate: dateFormatter.dateFromString(arrT[1])))
+            let bifurcateArray = String(arr).dashRemoval()
+            finalZoneArray.append(ToFromDate(fromDate: dateFormatter.dateFromString(bifurcateArray[0])!, toDate: dateFormatter.dateFromString(bifurcateArray[1])!))
         }
-        
-        
-        
         return finalZoneArray
     }
     
@@ -29,8 +26,8 @@ extension Array {
         dateFormatter.dateFormat = "HH:mm"
         var finalZoneArray = [String]()
         for arr in self {
-            let arrT = (arr as! ToFromDate)
-            finalZoneArray.append("\(dateFormatter.stringFromDate(arrT.fromDate!))-\(dateFormatter.stringFromDate(arrT.toDate!))")
+            let bifurcateArray = (arr as! ToFromDate)
+            finalZoneArray.append("\(dateFormatter.stringFromDate(bifurcateArray.fromDate))-\(dateFormatter.stringFromDate(bifurcateArray.toDate))")
         }
         
         

--- a/Yona/Yona/Challenges/TimeFrameTimeZoneChallengeViewController.swift
+++ b/Yona/Yona/Challenges/TimeFrameTimeZoneChallengeViewController.swift
@@ -9,8 +9,14 @@
 import UIKit
 
 struct ToFromDate {
-    var fromDate: NSDate?
-    var toDate: NSDate?
+    private static let formatter: NSDateFormatter = {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+    
+    var fromDate:NSDate = NSDate()
+    var toDate: NSDate = NSDate()
 }
 
 protocol TimeZoneChallengeDelegate: class {
@@ -45,6 +51,7 @@ class TimeFrameTimeZoneChallengeViewController: BaseViewController {
     var picker: YonaCustomDatePickerView?
     var activeIndexPath: NSIndexPath?
     var isFromButton: Bool = true
+    var tempToFromDate: ToFromDate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -69,9 +76,9 @@ class TimeFrameTimeZoneChallengeViewController: BaseViewController {
                 self.picker?.pickerTitleLabel.title = "From"
                 
                 if (self.activeIndexPath != nil) {
-                    self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[(self.activeIndexPath?.row)!].fromDate!)
+                    self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[(self.activeIndexPath?.row)!].fromDate)
                 } else {
-                    self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[self.zonesArrayDate.endIndex - 1].fromDate!)
+                    self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[self.zonesArrayDate.endIndex - 1].fromDate)
                 }
                 self.picker?.cancelButtonTitle.title = "Cancel"
                 self.picker?.okButtonTitle.title = "Next"
@@ -137,34 +144,28 @@ class TimeFrameTimeZoneChallengeViewController: BaseViewController {
      */
     private func configureTimeZone(doneValue: NSDate?) {
         if doneValue != nil {
-            
-            var tempArr: ToFromDate!
-            if activeIndexPath != nil {
-                tempArr = self.generateTimeZoneArray(isFrom: isFromButton, fromToValue: zonesArrayDate[(self.activeIndexPath?.row)!], withDoneValue: doneValue!)
-            } else {
-                tempArr = self.generateTimeZoneArray(isFrom: isFromButton, fromToValue: zonesArrayDate[zonesArrayDate.endIndex - 1], withDoneValue: doneValue!)
+            if tempToFromDate == nil {
+                tempToFromDate = ToFromDate()
             }
-            if self.isFromButton {
-                if activeIndexPath != nil {
-                    zonesArrayDate[(self.activeIndexPath?.row)!] = tempArr
-                    zonesArrayString = self.zonesArrayDate.convertToString()
+            if let unWrappedDoneValue = doneValue {
+                if isFromButton {
+                    tempToFromDate!.fromDate = unWrappedDoneValue
                 } else {
-                    zonesArrayDate[zonesArrayDate.endIndex - 1] = tempArr
-                    zonesArrayString = self.zonesArrayDate.convertToString()
-                }
-            } else {
-                if tempArr.toDate!.isGreaterThanDate(tempArr.fromDate!) {
-                    if activeIndexPath != nil {
-                        zonesArrayDate[(self.activeIndexPath?.row)!] = tempArr
-                        zonesArrayString = self.zonesArrayDate.convertToString()
-                    } else {
-                        zonesArrayDate[zonesArrayDate.endIndex - 1] = tempArr
-                        zonesArrayString = self.zonesArrayDate.convertToString()
+                    tempToFromDate!.toDate = unWrappedDoneValue
+                    if let unWrappedTempToFromDate = tempToFromDate {
+                        
+                        if (unWrappedTempToFromDate.toDate).isGreaterThanDate(unWrappedTempToFromDate.fromDate) {
+                            if activeIndexPath != nil {
+                                zonesArrayDate[(self.activeIndexPath?.row)!] = unWrappedTempToFromDate
+                                zonesArrayString = self.zonesArrayDate.convertToString()
+                            } else {
+                                zonesArrayDate.append(unWrappedTempToFromDate)
+                                zonesArrayString = self.zonesArrayDate.convertToString()
+                            }
+                        } else {
+                            displayAlertMessage("To time must be greater than From time", alertDescription: "")
+                        }
                     }
-                } else {
-                    zonesArrayString.removeLast()
-                    zonesArrayDate.removeLast()
-                    displayAlertMessage("To time must be greater than \(tempArr.fromDate!)", alertDescription: "")
                 }
             }
         }
@@ -173,7 +174,7 @@ class TimeFrameTimeZoneChallengeViewController: BaseViewController {
         
         if isFromButton {
             if (activeIndexPath != nil) {
-                picker?.hideShowDatePickerView(isToShow: true).configureWithTime(zonesArrayDate[(self.activeIndexPath?.row)!].toDate!)
+                picker?.hideShowDatePickerView(isToShow: true).configureWithTime(zonesArrayDate[(self.activeIndexPath?.row)!].toDate)
             } else {
                 picker?.hideShowDatePickerView(isToShow: true).configureWithTime(NSDate().dateRoundedDownTo15Minute())
             }
@@ -190,19 +191,6 @@ class TimeFrameTimeZoneChallengeViewController: BaseViewController {
                 self.tableView.reloadData()
             }
         }
-    }
-    
-    func generateTimeZoneArray(isFrom iFrom: Bool, fromToValue ft: ToFromDate, withDoneValue: NSDate) -> ToFromDate {
-        
-        var fromValue = ft.fromDate
-        var toValue = ft.toDate
-        
-        if iFrom {
-            fromValue = withDoneValue
-        } else {
-            toValue = withDoneValue
-        }
-        return ToFromDate(fromDate: fromValue, toDate: toValue)
     }
 }
 
@@ -225,14 +213,14 @@ extension TimeFrameTimeZoneChallengeViewController {
             self.isFromButton = true
             self.picker?.pickerTitleLabel("From")
             self.picker?.okButtonTitle.title = "Next"
-            self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[indexPath.row].fromDate!)
+            self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[indexPath.row].fromDate)
         }) { (cell) in
             self.activeIndexPath = indexPath
             self.isFromButton = false
             self.picker?.pickerTitleLabel("To")
             self.picker?.okButtonTitle.title = "Done"
             self.picker?.cancelButtonTitle.title = "Prev"
-            self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[indexPath.row].toDate!)
+            self.picker?.hideShowDatePickerView(isToShow: true).configureWithTime(self.zonesArrayDate[indexPath.row].toDate)
         }
         cell.rowNumber.text = String(indexPath.row + 1)
         
@@ -326,12 +314,6 @@ extension TimeFrameTimeZoneChallengeViewController {
     }
     
     @IBAction func addTimeZoneAction(sender: AnyObject) {
-        let df = NSDateFormatter()
-        df.dateFormat = "HH:mm"
-        let formattedTime = df.stringFromDate(NSDate().dateRoundedDownTo15Minute())
-        
-        zonesArrayString.append("\(formattedTime)-\(formattedTime)")
-        zonesArrayDate = zonesArrayString.converToDate()
         isFromButton = true
         picker?.pickerTitleLabel("From")
         picker?.okButtonTitle.title = "Next"


### PR DESCRIPTION
Date picker in timezone crash fixed
When user try to edit a timezone goal and enters the FROM time greater than TO time, App crashes.
The issue is in APPDEV-311 
http://jira.yona.nu/browse/APPDEV-311