### PR TITLE
Change notification BecomeActive to EnterForeground

### DIFF
--- a/Yona/Yona/DashBoard/BaseTabViewController.swift
+++ b/Yona/Yona/DashBoard/BaseTabViewController.swift
@@ -21,7 +21,7 @@ class BaseTabViewController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         updateSelectedIndex()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(BaseTabViewController.presentLoginScreen), name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(BaseTabViewController.presentLoginScreen), name: UIApplicationWillEnterForegroundNotification, object: nil)
     }
     
     


### PR DESCRIPTION
Login screens pops up evrytime when app becomes active. The behaviour should be it only displays when App comes to foreground