### PR TITLE
Bugfixes/appdev 410

### DIFF
--- a/Yona/Yona/Challenges/Challenges.storyboard
+++ b/Yona/Yona/Challenges/Challenges.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="QvV-Rl-xbI">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="QvV-Rl-xbI">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -858,7 +858,7 @@ Pinterest, Instagram, Snapchat</string>
                                                     <constraint firstAttribute="height" constant="30" id="7WT-gr-Ryy"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" name="Oswald-Light" family="Oswald" pointSize="32"/>
-                                                <state key="normal" title="10">
+                                                <state key="normal" title="1">
                                                     <color key="titleColor" red="0.1843137255" green="0.1843137255" blue="0.1843137255" alpha="1" colorSpace="calibratedRGB"/>
                                                 </state>
                                                 <connections>

--- a/Yona/Yona/Challenges/TimeBucketChallenges.swift
+++ b/Yona/Yona/Challenges/TimeBucketChallenges.swift
@@ -59,12 +59,13 @@ class TimeBucketChallenges: BaseViewController, UIScrollViewDelegate, BudgetChal
     // MARK: - View
     override func viewDidLoad() {
         super.viewDidLoad()
+        //It will select NoGo tab by default
+        setTimeBucketTabToDisplay(.noGo, key: YonaConstants.nsUserDefaultsKeys.timeBucketTabToDisplay)
     }
     
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        //It will select NoGo tab by default
-        
+       
         self.tableView.estimatedRowHeight = 100
         self.setupUI()
         self.callActivityCategory()

--- a/Yona/Yona/Challenges/TimeBucketChallenges.swift
+++ b/Yona/Yona/Challenges/TimeBucketChallenges.swift
@@ -59,13 +59,12 @@ class TimeBucketChallenges: BaseViewController, UIScrollViewDelegate, BudgetChal
     // MARK: - View
     override func viewDidLoad() {
         super.viewDidLoad()
-
     }
     
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         //It will select NoGo tab by default
-        setTimeBucketTabToDisplay(.noGo, key: YonaConstants.nsUserDefaultsKeys.timeBucketTabToDisplay)
+        
         self.tableView.estimatedRowHeight = 100
         self.setupUI()
         self.callActivityCategory()
@@ -94,7 +93,8 @@ class TimeBucketChallenges: BaseViewController, UIScrollViewDelegate, BudgetChal
     
     override func viewDidAppear(animated:Bool) {
         super.viewDidAppear(animated)
-        
+        setTimeBucketTabToDisplay(.noGo, key: YonaConstants.nsUserDefaultsKeys.timeBucketTabToDisplay)
+
     }
     
     //Delegate fires

--- a/Yona/Yona/Challenges/TimeFrameBudgetChallengeViewController.swift
+++ b/Yona/Yona/Challenges/TimeFrameBudgetChallengeViewController.swift
@@ -51,17 +51,14 @@ class TimeFrameBudgetChallengeViewController: BaseViewController {
 
         footerGradientView.colors = [UIColor.yiWhiteTwoColor(), UIColor.yiWhiteTwoColor()]
         
-        configurePickerView()
+        
         self.setChallengeButton.setTitle(NSLocalizedString("challenges.addBudgetGoal.setChallengeButton", comment: "").uppercaseString, forState: UIControlState.Normal)
         self.timeZoneLabel.text = NSLocalizedString("challenges.addBudgetGoal.budgetLabel", comment: "")
         self.minutesPerDayLabel.text = NSLocalizedString("challenges.addBudgetGoal.minutesPerDayLabel", comment: "")
         self.bottomLabelText.text = NSLocalizedString("challenges.addBudgetGoal.bottomLabelText", comment: "")
 
         
-        if let maxDurationMinutesUnwrapped = goalCreated?.maxDurationMinutes {
-            maxDurationMinutes = String(maxDurationMinutesUnwrapped)
-            self.maxTimeButton.setTitle(String(maxDurationMinutesUnwrapped), forState: UIControlState.Normal)
-        }
+        
         
         let localizedString = NSLocalizedString("challenges.addBudgetGoal.budgetChallengeDescription", comment: "")
         
@@ -73,6 +70,11 @@ class TimeFrameBudgetChallengeViewController: BaseViewController {
             }
             self.maxTimeButton.setTitle(String(maxDurationMinutes), forState: UIControlState.Normal)
         } else {
+            if let maxDurationMinutesUnwrapped = goalCreated?.maxDurationMinutes {
+                maxDurationMinutes = String(maxDurationMinutesUnwrapped)
+                self.maxTimeButton.setTitle(String(maxDurationMinutesUnwrapped), forState: UIControlState.Normal)
+            }
+            
             if ((goalCreated?.editLinks?.isEmpty) != nil) {
                 self.navigationItem.rightBarButtonItem = self.deleteGoalButton
 
@@ -83,6 +85,7 @@ class TimeFrameBudgetChallengeViewController: BaseViewController {
                 self.budgetChallengeDescription.text = String(format: localizedString, activityName)
             }
         }
+        configurePickerView()
     }
     
     override func viewWillDisappear(animated: Bool) {


### PR DESCRIPTION
 User always navigates back NO GO screen irrespective of type of goal he is adding. - Fixed

 Every new Budget goal pick up default time value from last deleted Budget/Credit goal.  - Fixed

Budget goal time values defaults to 0 instead of 1  - Fixed