### PR TITLE
APPDEV-1138 Correct support email address

### DIFF
--- a/Yona/Yona/Settings/SettingsViewController.swift
+++ b/Yona/Yona/Settings/SettingsViewController.swift
@@ -320,7 +320,7 @@ extension SettingsViewController:UITableViewDelegate {
                 
                  body = userlink + "\n\n" + "Password: '" + yonaPassword + "'"
             }
-            let email = "app@yona.nu"
+            let email = "support@yona.nu"
         
         
             UINavigationBar.appearance().tintColor = UIColor.yiMidBlueColor()


### PR DESCRIPTION
Currently, the address is said to be app@yona.nu, but it should be support@yona.nu