### PR TITLE
APPDEV-1148 Append country code prefix before mobile number

### DIFF
--- a/Yona/Yona/StringExtensions.swift
+++ b/Yona/Yona/StringExtensions.swift
@@ -43,8 +43,8 @@ extension String {
     
     func formatNumber(prefix: String) -> String {
         var number = self
-        if !prefix.isEmpty && !prefix.hasPrefix("+")  {
-            number = "+" + number
+        if !prefix.isEmpty && !number.hasPrefix("+") {
+            number = "+" + prefix + number
         }
         return number.removeWhitespace().removeBrackets().formatDutchCountryCodePrefix()
     }

--- a/Yona/YonaTests/MobileNumberValidationTests.swift
+++ b/Yona/YonaTests/MobileNumberValidationTests.swift
@@ -49,6 +49,28 @@ class MobileNumberValidationTests: XCTestCase {
         XCTAssertEqual(result, formattedMobileNumber)
     }
     
+    func testMobileNumberWithoutPrefixAndPlusSign(){
+        let mobileNumber = "(0)612345678"
+        let expectedResult = "612345678"
+        XCTAssertEqual(mobileNumber.formatNumber(prefix: ""), expectedResult)
+    }
     
+    func testMobileNumberWithPlusSignAndPrefix(){
+        let mobileNumber = "+31(0)612345678"
+        let expectedResult = "+31612345678"
+        XCTAssertEqual(mobileNumber.formatNumber(prefix: "31"), expectedResult)
+    }
     
+    func testMobileNumberWithPlusSignAndWithoutPrefix(){
+        let mobileNumber = "+31(0)612345678"
+        let expectedResult = "+31612345678"
+        XCTAssertEqual(mobileNumber.formatNumber(prefix: ""), expectedResult)
+    }
+    
+    func testMobileNumberWithPrefixWithoutPlusSign(){
+        let mobileNumber = "(0)612345678"
+        let expectedResult = "+31612345678"
+        XCTAssertEqual(mobileNumber.formatNumber(prefix: "31"), expectedResult)
+    }
+
 }


### PR DESCRIPTION
- Corrected logic to append prefix after `+` sign
- Added few more unit test cases for formatting number