### PR TITLE
APPDEV-1113 Take device-specific links from the device entity

### DIFF
--- a/Yona/Yona.xcodeproj/project.pbxproj
+++ b/Yona/Yona.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		E55BC485211091D90023FA43 /* fabric_script.sh in Resources */ = {isa = PBXBuildFile; fileRef = E55BC484211091D90023FA43 /* fabric_script.sh */; };
 		E58A11342119B2C2004E8086 /* MobileNumberValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58A11332119B2C2004E8086 /* MobileNumberValidationTests.swift */; };
 		E5B93782210F42CC00B5413B /* fabric.apikey in Resources */ = {isa = PBXBuildFile; fileRef = E5B93781210F42CC00B5413B /* fabric.apikey */; };
+		E5CD909221EC676D005AEF60 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CD909121EC676D005AEF60 /* Device.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -650,6 +651,7 @@
 		E55BC484211091D90023FA43 /* fabric_script.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = fabric_script.sh; sourceTree = "<group>"; };
 		E58A11332119B2C2004E8086 /* MobileNumberValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileNumberValidationTests.swift; sourceTree = "<group>"; };
 		E5B93781210F42CC00B5413B /* fabric.apikey */ = {isa = PBXFileReference; lastKnownFileType = text; path = fabric.apikey; sourceTree = "<group>"; };
+		E5CD909121EC676D005AEF60 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		F96A01827A243F17998DC35A /* Pods_Yona.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Yona.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1023,6 +1025,7 @@
 				16FDABDD1D53D2BE00B847DB /* TimeLineDayActivityOverview.swift */,
 				16FDABDB1D53D2A000B847DB /* TimeLineDayActivities.swift */,
 				16FDABDF1D53D2E500B847DB /* TimeLineDayActivitiesForUsers.swift */,
+				E5CD909121EC676D005AEF60 /* Device.swift */,
 			);
 			name = DAOObjects;
 			sourceTree = "<group>";
@@ -1786,6 +1789,7 @@
 				ADD108311CC7CB920048852F /* TimeFrameBudgetChallengeViewController.swift in Sources */,
 				D9C7902D1CC2E989007DDF46 /* Extensions.swift in Sources */,
 				1656A5A61D4BE6B300EB288D /* RouteRequest.m in Sources */,
+				E5CD909221EC676D005AEF60 /* Device.swift in Sources */,
 				9054D54A1D65EBAC0060D22E /* ReplyToComment.swift in Sources */,
 				9042C74F1CD898E300100306 /* UILabel+AGi18n.m in Sources */,
 				1656A3EE1D4A79A500EB288D /* YonaInstructionMobilePage4.swift in Sources */,

--- a/Yona/Yona/DataService/Users.swift
+++ b/Yona/Yona/DataService/Users.swift
@@ -18,6 +18,7 @@ struct Users{
     
     var buddies : [Buddies] = []
     var userGoals : [Goal] = []
+    var devices : [Device] = []
     //links
     var editLink: String?
     var confirmMobileNumberLink: String?
@@ -27,7 +28,6 @@ struct Users{
     var dailyActivityReportsLink: String?
     var weeklyActivityReportsLink: String?
     var newDeviceRequestsLink: String?
-    var appActivityLink: String?
     var activityCategoryLink: String?
     var requestPinResetLink: String?
     var requestPinVerifyLink: String?
@@ -40,9 +40,7 @@ struct Users{
     var formatetMobileNumber : String!
     var editUserAvatar: String?
     var userAvatarLink: String?
-    var openAppEventLink: String?
     
-    var mobilConfigFileURL: String = ""
     init(userData: BodyDataDictionary) {
         
         userID = "NOID"
@@ -56,7 +54,6 @@ struct Users{
             KeychainManager.sharedInstance.setPassword(yonapassword)
             //get the links
             if let links = userData[YonaConstants.jsonKeys.linksKeys] {
-                
                 // this is for when parsing user body returned from add device, to get the self link to the user
                 if let yonaUserSelfLink = links[YonaConstants.jsonKeys.yonaUserSelfLink],
                     let hrefyonaUserSelfLink = (yonaUserSelfLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
@@ -65,17 +62,11 @@ struct Users{
                     foundIncludeLink = true
                 }
                 
-                if let yonaOpenAppEventLink = links[YonaConstants.jsonKeys.yonaOpenAppEventLink],
-                    let hrefYonaOpenAppEventLink = (yonaOpenAppEventLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
-                    self.openAppEventLink = hrefYonaOpenAppEventLink
-                }
-                
                 if let editLink = links[YonaConstants.jsonKeys.editLinkKeys],
                     let hrefEditLink = (editLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
                     self.newDeviceRequestsLink = hrefEditLink
                 }
             }
-        //} else {
             
             if let firstName = userData[addUserKeys.firstNameKey.rawValue] as? String {// firstName
                 self.firstName = firstName
@@ -149,11 +140,6 @@ struct Users{
                     self.newDeviceRequestsLink = newDeviceRequestsLinksSelfHref
                 }
                 
-                if let appActivityLinks = links[YonaConstants.jsonKeys.yonaAppActivity],
-                    let hrefappActivityLinks = (appActivityLinks as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
-                    self.appActivityLink = hrefappActivityLinks
-                }
-                
                 if let requestPinResetLinks = links[YonaConstants.jsonKeys.yonaPinRequest],
                     let hrefrequestPinResetLinks = (requestPinResetLinks as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
                     self.requestPinResetLink = hrefrequestPinResetLinks
@@ -177,10 +163,6 @@ struct Users{
                     let timeline  = (requestPinClearLinks as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
                     timeLineLink = timeline
                 }
-                if let requestPinClearLinks = links[YonaConstants.jsonKeys.yonaappleMobileConfig],
-                    let mobilconfig  = (requestPinClearLinks as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
-                    mobilConfigFileURL = mobilconfig
-                }
 
                 if let yonaEditPhotoLink = links[YonaConstants.jsonKeys.yonaEditUserPhoto],
                     let href  = (yonaEditPhotoLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
@@ -199,6 +181,17 @@ struct Users{
                 let selfGoalsLink = (goalsLink as? [String : Any])?[YonaConstants.jsonKeys.selfLinkKeys],
                 let hrefSelfGoalsLink = (selfGoalsLink as? [String : Any])?[YonaConstants.jsonKeys.hrefKey]{
                 self.getAllGoalsLink = hrefSelfGoalsLink as? String
+            }
+            
+            if let embedded = userData[YonaConstants.jsonKeys.embedded],
+                let yonaDevice = embedded[YonaConstants.jsonKeys.yonaDevice],
+                let embeddedNext = (yonaDevice as? [String : Any])?[YonaConstants.jsonKeys.embedded] {
+                if let DevicesJSON  = (embeddedNext as? [String : Any])?[YonaConstants.jsonKeys.yonaDevice] as? [BodyDataDictionary] {
+                    for each in DevicesJSON {
+                        let aDevice = Device(deviceData: each)
+                        devices.append(aDevice)
+                    }
+                }
             }
             
             //for now this is the only way to get the activity category link
@@ -264,8 +257,4 @@ struct Users{
             body["nickname"] = nickname
         return body as BodyDataDictionary
     }
-    
-    
-    
-
 }

--- a/Yona/Yona/Device.swift
+++ b/Yona/Yona/Device.swift
@@ -1,0 +1,38 @@
+//
+//  Device.swift
+//  Yona
+//
+//  Created by Vishal Revdiwala on 11/01/19.
+//  Copyright © 2019 Yona. All rights reserved.
+//
+
+import Foundation
+
+struct Device {
+    
+    var isRequestingDevice: Bool?
+    var appActivityLink: String?
+    var openAppEventLink: String?
+    var mobileConfigLink: String?
+    
+    init(deviceData: BodyDataDictionary) {
+        self.isRequestingDevice = deviceData[YonaConstants.jsonKeys.requestingDevice] as? Bool
+        
+        if let links = deviceData[YonaConstants.jsonKeys.linksKeys] {
+            if let appActivityLinks = links[YonaConstants.jsonKeys.yonaAppActivity],
+                let hrefAppActivityLinks = (appActivityLinks as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
+                self.appActivityLink = hrefAppActivityLinks
+            }
+            
+            if let yonaOpenAppEventLink = links[YonaConstants.jsonKeys.yonaOpenAppEventLink],
+                let hrefYonaOpenAppEventLink = (yonaOpenAppEventLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
+                self.openAppEventLink = hrefYonaOpenAppEventLink
+            }
+            
+            if let yonaAppleMobileConfigLink = links[YonaConstants.jsonKeys.yonaAppleMobileConfig],
+                let mobileConfig  = (yonaAppleMobileConfigLink as? [String : String])?[YonaConstants.jsonKeys.hrefKey] {
+                self.mobileConfigLink = mobileConfig
+            }
+        }
+    }
+}

--- a/Yona/Yona/Others/Constants.swift
+++ b/Yona/Yona/Others/Constants.swift
@@ -59,7 +59,8 @@ struct YonaConstants {
         static let  yonaGoals = "yona:goals"
         static let  yonaBuddies = "yona:buddies"
         static let  yonaBuddy = "yona:buddy"
-
+        static let  yonaDevice = "yona:devices"
+        static let  requestingDevice = "requestingDevice"
         static let  name = "name"
         static let  applications = "applications"
         static let  description = "description"
@@ -92,8 +93,7 @@ struct YonaConstants {
         static let  hrefKey = "href"
 
         
-        static let  yonaappleMobileConfig = "yona:appleMobileConfig"
-        
+        static let  yonaAppleMobileConfig = "yona:appleMobileConfig"
         static let  dayActivities = "dayActivities"
         static let  dayActivitiesForUsers = "dayActivitiesForUsers"
         static let  yonaDayActivityOverviews = "yona:dayActivityOverviews"

--- a/Yona/Yona/UserRequestManager.swift
+++ b/Yona/Yona/UserRequestManager.swift
@@ -75,16 +75,10 @@ class UserRequestManager{
     
     
     func postOpenAppEvent(_ user: Users, onCompletion: @escaping APIResponse) {
-        var openAppEventLinkPath: String?
-        for temp in user.devices {
-            if temp.isRequestingDevice! {
-                openAppEventLinkPath = temp.openAppEventLink
-            }
-        }
-        
+        let openAppEventLinkPath = user.devices.first(where: { $0.isRequestingDevice! }).map {$0.openAppEventLink}
         if let path = openAppEventLinkPath, let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]  as? String, let appVersionCode = Bundle.main.infoDictionary?["CFBundleVersion"]  as? String {
             let bodyForOpenAppEvent = ["operatingSystem": "IOS", "appVersion": appVersion, "appVersionCode":appVersionCode] as BodyDataDictionary
-            genericUserRequest(httpMethods.post, path: path, userRequestType: userRequestTypes.postUser, body: bodyForOpenAppEvent, onCompletion: { (success, message, code, nil) in
+            genericUserRequest(httpMethods.post, path: path!, userRequestType: userRequestTypes.postUser, body: bodyForOpenAppEvent, onCompletion: { (success, message, code, nil) in
                 onCompletion(success, message, code)
             })
         } else {
@@ -217,14 +211,9 @@ class UserRequestManager{
     }
     
     func getMobileConfigFile( _ onCompletion: @escaping APIMobileConfigResponse) {
-        var mobileConfigFileURL: String?
-        for temp in (self.newUser?.devices)! {
-            if temp.isRequestingDevice! {
-                mobileConfigFileURL = temp.mobileConfigLink
-            }
-        }
+        let mobileConfigFileURL = self.newUser?.devices.first(where: { $0.isRequestingDevice! }).map {$0.mobileConfigLink}
         if let mobileConfigURL = mobileConfigFileURL {
-            APIServiceManager.sharedInstance.callRequestWithAPIMobileConfigResponse(nil, path: mobileConfigURL, httpMethod: httpMethods.get, onCompletion: onCompletion)
+            APIServiceManager.sharedInstance.callRequestWithAPIMobileConfigResponse(nil, path: mobileConfigURL!, httpMethod: httpMethods.get, onCompletion: onCompletion)
         }
     }
     

--- a/Yona/Yona/UserRequestManager.swift
+++ b/Yona/Yona/UserRequestManager.swift
@@ -75,7 +75,14 @@ class UserRequestManager{
     
     
     func postOpenAppEvent(_ user: Users, onCompletion: @escaping APIResponse) {
-        if let path = user.openAppEventLink, let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]  as? String, let appVersionCode = Bundle.main.infoDictionary?["CFBundleVersion"]  as? String {
+        var openAppEventLinkPath: String?
+        for temp in user.devices {
+            if temp.isRequestingDevice! {
+                openAppEventLinkPath = temp.openAppEventLink
+            }
+        }
+        
+        if let path = openAppEventLinkPath, let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]  as? String, let appVersionCode = Bundle.main.infoDictionary?["CFBundleVersion"]  as? String {
             let bodyForOpenAppEvent = ["operatingSystem": "IOS", "appVersion": appVersion, "appVersionCode":appVersionCode] as BodyDataDictionary
             genericUserRequest(httpMethods.post, path: path, userRequestType: userRequestTypes.postUser, body: bodyForOpenAppEvent, onCompletion: { (success, message, code, nil) in
                 onCompletion(success, message, code)
@@ -210,9 +217,15 @@ class UserRequestManager{
     }
     
     func getMobileConfigFile( _ onCompletion: @escaping APIMobileConfigResponse) {
-       if let mobileConfigURL = self.newUser?.mobilConfigFileURL {
-           APIServiceManager.sharedInstance.callRequestWithAPIMobileConfigResponse(nil, path: mobileConfigURL, httpMethod: httpMethods.get, onCompletion: onCompletion)
+        var mobileConfigFileURL: String?
+        for temp in (self.newUser?.devices)! {
+            if temp.isRequestingDevice! {
+                mobileConfigFileURL = temp.mobileConfigLink
             }
+        }
+        if let mobileConfigURL = mobileConfigFileURL {
+            APIServiceManager.sharedInstance.callRequestWithAPIMobileConfigResponse(nil, path: mobileConfigURL, httpMethod: httpMethods.get, onCompletion: onCompletion)
+        }
     }
     
     func convertToDictionary(text: String) -> [String: Any]? {


### PR DESCRIPTION
- Created new model class for Device entity and accordingly code update
   Currently following links consumed for iOS: `appleMobileConfig` and `postOpenAppEvent`
- Code refactor 