### PR TITLE
APPDEV-1254 HTTP scheme issue

### DIFF
--- a/Yona/Yona/UserRequestManager.swift
+++ b/Yona/Yona/UserRequestManager.swift
@@ -126,7 +126,7 @@ class UserRequestManager{
     func getUser(_ userRequestType: GetUserRequest, onCompletion: @escaping APIUserResponse) {
         
         if var selfUserLink = KeychainManager.sharedInstance.getUserSelfLink(){
-            selfUserLink = getUserFetchURL()
+            selfUserLink = correctUserFetchUrlIfNeeded(storedUserUrl: selfUserLink)
             if self.newUser == nil || UserDefaults.standard.bool(forKey: YonaConstants.nsUserDefaultsKeys.isBlocked) || userRequestType == GetUserRequest.allowed { //if blocked because of pinreset
                 #if DEBUG
                     print("***** Get User API call ******")
@@ -143,18 +143,17 @@ class UserRequestManager{
         }
     }
     
-    func getUserFetchURL() -> String {
-        return compareAndSwapSchemes(leftURL: getSavedUserFromUserDefaults().getSelfLink!, rightURL: EnvironmentManager.baseUrlString()!,userLinkFromKeychain: KeychainManager.sharedInstance.getUserSelfLink()!)
-    }
+    func correctUserFetchUrlIfNeeded(storedUserUrl: String) -> String {
+        return compareAndSwapSchemes(userURLStr: getSavedUserFromUserDefaults().getSelfLink!, environmentBaseURLStr: EnvironmentManager.baseUrlString()!,storedUserUrlStr: storedUserUrl)    }
     
-    func compareAndSwapSchemes(leftURL:String, rightURL:String, userLinkFromKeychain:String) -> String {
-        let userURL = URL(string: leftURL)
-        let environmentBaseURL = URL(string: rightURL)
+    func compareAndSwapSchemes(userURLStr:String, environmentBaseURLStr:String, storedUserUrlStr:String) -> String {
+        let userURL = URL(string: userURLStr)
+        let environmentBaseURL = URL(string: environmentBaseURLStr)
         if userURL?.scheme != environmentBaseURL?.scheme {
             let formattedURLString = userURL?.absoluteString.deletePrefix((userURL?.scheme)!)
             return environmentBaseURL!.scheme! + formattedURLString!
         }
-        return userLinkFromKeychain //return as there is no mess up of URLs which is cause of the issue YD-621
+        return storedUserUrlStr //return as there is no mess up of URLs which is cause of the issue YD-621
     }
     
     func getSavedUserFromUserDefaults() -> Users {

--- a/Yona/Yona/UserRequestManager.swift
+++ b/Yona/Yona/UserRequestManager.swift
@@ -144,9 +144,9 @@ class UserRequestManager{
     }
     
     func correctUserFetchUrlIfNeeded(storedUserUrl: String) -> String {
-        return compareAndSwapSchemes(userURLStr: getSavedUserFromUserDefaults().getSelfLink!, environmentBaseURLStr: EnvironmentManager.baseUrlString()!,storedUserUrlStr: storedUserUrl)    }
+        return correctUserFetchUrlIfNeeded(userURLStr: getSavedUserFromUserDefaults().getSelfLink!, environmentBaseURLStr: EnvironmentManager.baseUrlString()!,storedUserUrlStr: storedUserUrl)    }
     
-    func compareAndSwapSchemes(userURLStr:String, environmentBaseURLStr:String, storedUserUrlStr:String) -> String {
+    func correctUserFetchUrlIfNeeded(userURLStr:String, environmentBaseURLStr:String, storedUserUrlStr:String) -> String {
         let userURL = URL(string: userURLStr)
         let environmentBaseURL = URL(string: environmentBaseURLStr)
         if userURL?.scheme != environmentBaseURL?.scheme {

--- a/Yona/Yona/UserRequestManager.swift
+++ b/Yona/Yona/UserRequestManager.swift
@@ -154,7 +154,7 @@ class UserRequestManager{
             let formattedURLString = userURL?.absoluteString.deletePrefix((userURL?.scheme)!)
             return environmentBaseURL!.scheme! + formattedURLString!
         }
-        return userLinkFromKeychain //return as there is no mess up of URLs which is cause of the issue YD-612
+        return userLinkFromKeychain //return as there is no mess up of URLs which is cause of the issue YD-621
     }
     
     func getSavedUserFromUserDefaults() -> Users {

--- a/Yona/YonaTests/EnvironmentSwitchTests.swift
+++ b/Yona/YonaTests/EnvironmentSwitchTests.swift
@@ -35,7 +35,7 @@ class EnvironmentSwitchTests: XCTestCase {
         let environmentURL = "https://app.prd.yona.nu/"
         let keychainURL = "/xyz"
         let expectedURL = "https://app.prd.yona.nu/xyz"
-        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(leftURL: userDBURL, rightURL: environmentURL, userLinkFromKeychain: keychainURL)
+        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
          XCTAssertEqual(result, expectedURL)
     }
     
@@ -44,7 +44,7 @@ class EnvironmentSwitchTests: XCTestCase {
         let environmentURL = "https://app.prd.yona.nu/"
         let keychainURL = "/xyz"
         let expectedURL = keychainURL
-        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(leftURL: userDBURL, rightURL: environmentURL, userLinkFromKeychain: keychainURL)
+        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
          XCTAssertEqual(result, expectedURL)
     }
 }

--- a/Yona/YonaTests/EnvironmentSwitchTests.swift
+++ b/Yona/YonaTests/EnvironmentSwitchTests.swift
@@ -35,7 +35,7 @@ class EnvironmentSwitchTests: XCTestCase {
         let environmentURL = "https://app.prd.yona.nu/"
         let keychainURL = "/xyz"
         let expectedURL = "https://app.prd.yona.nu/xyz"
-        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
+        let result = UserRequestManager.sharedInstance.correctUserFetchUrlIfNeeded(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
          XCTAssertEqual(result, expectedURL)
     }
     
@@ -44,7 +44,7 @@ class EnvironmentSwitchTests: XCTestCase {
         let environmentURL = "https://app.prd.yona.nu/"
         let keychainURL = "/xyz"
         let expectedURL = keychainURL
-        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
+        let result = UserRequestManager.sharedInstance.correctUserFetchUrlIfNeeded(userURLStr: userDBURL, environmentBaseURLStr: environmentURL, storedUserUrlStr: keychainURL)
          XCTAssertEqual(result, expectedURL)
     }
 }

--- a/Yona/YonaTests/EnvironmentSwitchTests.swift
+++ b/Yona/YonaTests/EnvironmentSwitchTests.swift
@@ -12,6 +12,7 @@ import XCTest
 class EnvironmentSwitchTests: XCTestCase {
     
     let welcome = WelcomeViewController()
+    let user = UserRequestManager.sharedInstance
     
     override func setUp() {
         super.setUp()
@@ -27,5 +28,23 @@ class EnvironmentSwitchTests: XCTestCase {
         let expectedURL = "https://app.prd.yona.nu/"
         let result = welcome.removeWhitespaceFromURL(url: "https://app.prd.yona.nu/      ")
         XCTAssertEqual(result, expectedURL)
+    }
+    
+    func testcompareAndSwapSchemes_positive(){
+        let userDBURL = "http://app.prd.yona.nu/xyz"
+        let environmentURL = "https://app.prd.yona.nu/"
+        let keychainURL = "/xyz"
+        let expectedURL = "https://app.prd.yona.nu/xyz"
+        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(leftURL: userDBURL, rightURL: environmentURL, userLinkFromKeychain: keychainURL)
+         XCTAssertEqual(result, expectedURL)
+    }
+    
+    func testcompareAndSwapSchemes_negative(){
+        let userDBURL = "https://app.prd.yona.nu/xyz"
+        let environmentURL = "https://app.prd.yona.nu/"
+        let keychainURL = "/xyz"
+        let expectedURL = keychainURL
+        let result = UserRequestManager.sharedInstance.compareAndSwapSchemes(leftURL: userDBURL, rightURL: environmentURL, userLinkFromKeychain: keychainURL)
+         XCTAssertEqual(result, expectedURL)
     }
 }


### PR DESCRIPTION
- Code for url scheme comparison
- Added test case

-- Here if schemes (http or https) of environment logged in and `self->link` of locally stored user are different, it will update the scheme to be former one. Else it return link from keychain as there is no mess up links.